### PR TITLE
Act based on RFC and return NOERROR and nodata

### DIFF
--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -28,7 +28,7 @@ coredns:
     - name: forward
       parameters: . /etc/resolv.conf
     - name: k8s_crd 
-      parameters: .
+      parameters: example.org
       configBlock: |-
         resources DNSEndpoint
         apex dns1

--- a/gateway.go
+++ b/gateway.go
@@ -162,9 +162,6 @@ func (gw *Gateway) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	switch state.QType() {
 	case dns.TypeA:
 		m.Answer = gw.A(state, addrs, ttl)
-	case dns.TypeAAAA:
-		m.Ns = []dns.RR{gw.soa(state)}
-		m.Rcode = dns.RcodeNameError
 	default:
 		m.Ns = []dns.RR{gw.soa(state)}
 	}

--- a/terratest/test/basic_test.go
+++ b/terratest/test/basic_test.go
@@ -107,9 +107,16 @@ func TestBasicExample(t *testing.T) {
 		assert.Equal(t, uint32(123), msg.Answer[0].(*dns.A).Hdr.Ttl)
 	})
 
-	t.Run("Type AAAA returns Rcode 3", func(t *testing.T) {
+	t.Run("Type AAAA returns Rcode 0", func(t *testing.T) {
 		msg, err := DigMsg(t, "localhost", 1053, "host1.example.org", dns.TypeAAAA)
 		require.NoError(t, err)
+		assert.Equal(t, dns.RcodeSuccess, msg.Rcode)
+		assert.Equal(t, 0, len(msg.Answer))
+	})
+	t.Run("Type AAAA returns Rcode 3 for non existing host", func(t *testing.T) {
+		msg, err := DigMsg(t, "localhost", 1053, "nonexistent.example.org", dns.TypeAAAA)
+		require.NoError(t, err)
 		assert.Equal(t, dns.RcodeNameError, msg.Rcode)
+		assert.Equal(t, 0, len(msg.Answer))
 	})
 }


### PR DESCRIPTION
https://tools.ietf.org/html/rfc4074#section-3 suggests we have to
return NOERROR status and NODATA (empty reply)

Fixes https://github.com/AbsaOSS/coredns-crd-plugin/issues/11

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>